### PR TITLE
resolved tokentimelock contract ambiguity

### DIFF
--- a/util/helpers.ts
+++ b/util/helpers.ts
@@ -96,10 +96,10 @@ export async function deployTokenTimelock(
   confirmations: number = config.confirmationsForDeploy
 ): Promise<TokenTimelock> {
   const tokenTimelockFactory = await ethers.getContractFactory(
-    "TokenTimelock",
+    "contracts/TokenTimelock.sol:TokenTimelock",
     deployer
   );
-  const tokenTimelock = await tokenTimelockFactory.deploy(camoTokenAddress);
+  const tokenTimelock = await tokenTimelockFactory.deploy(camoTokenAddress) as TokenTimelock;
   await ethers.provider.waitForTransaction(
     tokenTimelock.deployTransaction.hash,
     confirmations


### PR DESCRIPTION
Noticed one of the tests failing because of contract ambiguity between `@openzeppelin/contracts/token/ERC20/utils/TokenTimelock.sol:TokenTimelock` 
and `contracts/TokenTimelock.sol:TokenTimelock`

This is now resolved in this PR.